### PR TITLE
Allow devs to override delay and what environments it impacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
 # ember-cli-delay-app-boot
 
-This addon adds a 250ms delay to initial application boot for development builds, i.e. `--environment=development` (which is the default).  This seems pretty silly to most folks, and is only something you
-should include if you are struggling with Chrome loading your sourcemap files. Adding a small amount of async during app boot
-allows Chrome to grab the sourcemaps before kicking off the app load process (and hitting any debuggers you might have).
+This addon adds a delay (250ms by default) to initial application boot for certain builds; e.g. `--environment=development` by default.
+
+This is useful in certain cases, such as giving Chrome enough time to load your [Source Map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) files before your app boots and any debuggers are hit. ([chromium#424191](https://code.google.com/p/chromium/issues/detail?id=424191))
+
+This manifests as your `debugger` statement getting stuck with:
+```js
+// Please wait a bit.
+// Compiled script is not shown while source map is being loaded!
+```
 
 ## Installation
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
+* `ember install:addon ember-cli-delay-app-boot`
 
-## Running
+## Configuration (optional)
 
-* `ember server`
-* Visit your app at http://localhost:4200.
+By default, a delay of 250ms is used only when `--environment=development`. You can change these options in your app's `Brocfile.js`:
 
-## Running Tests
-
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
+```js
+var app = new EmberApp({
+  'delay-app-boot': {
+    // Delay in milliseconds
+    delay: 250,
+    // Array of environments that should have the boot delay
+    environments: ['development']
+  }
+});
+```
 
 ## Deploying to Production
 When you deploy to production using the `--environment=production` flag, this addon is inert and *does not* artificially slow down your app's boot time.

--- a/index.js
+++ b/index.js
@@ -7,17 +7,33 @@ function calculateAppConfig(config) {
 
 module.exports = {
   name: 'ember-cli-delay-app-boot',
+  
+  initializeOptions: function() {
+    var defaultOptions = {
+      delay: 250,
+      environments: ['development']
+    };
 
+    this.options = this.app.options['delay-app-boot'] || {};
+
+    for (var option in defaultOptions) {
+      if (!this.options.hasOwnProperty(option)) {
+        this.options[option] = defaultOptions[option];
+      }
+    }
+  },
+  
   contentFor: function(type, config) {
-    if (type === 'app-boot' && this.app.env !== 'production') {
+    if (type === 'app-boot' && this.options.environments.indexOf(this.app.env) !== -1) {
       return 'setTimeout(function() {\n' +
                'require("' + config.modulePrefix + '/app")["default"]' +
                  '.create(' + calculateAppConfig(config) + ');\n' +
-              '}, 250);';
+              '}, ' + this.options.delay + ');';
     }
   },
 
   included: function() {
     this.app.options.autoRun = false;
+    this.initializeOptions();
   }
 };


### PR DESCRIPTION
Makes the addon usable for cases other than just "Chrome needs 250ms" and also makes it ready for when ember-cli supports custom environments.
